### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/arlyon/linear-motion/compare/v0.1.1...v0.2.0) - 2026-04-15
+
+### Other
+- use default token
+- add waybar suppoort
+- add cronjob guide w/ systemd
+- use personal token so that releases are triggered correctly
+
 ## [0.1.1](https://github.com/arlyon/linear-motion/compare/v0.1.0...v0.1.1) - 2025-09-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "linear-motion"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linear-motion"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/arlyon/linear-motion"
 description = "A CLI tool for syncing between Linear and Motion"


### PR DESCRIPTION



## 🤖 New release

* `linear-motion`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `linear-motion` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Commands::List 4 -> 6 in /tmp/.tmpFvY9lx/linear-motion/src/cli/commands.rs:76

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Commands:Tasks in /tmp/.tmpFvY9lx/linear-motion/src/cli/commands.rs:61
  variant Commands:Complete in /tmp/.tmpFvY9lx/linear-motion/src/cli/commands.rs:67
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/arlyon/linear-motion/compare/v0.1.1...v0.2.0) - 2026-04-15

### Other
- use default token
- add waybar suppoort
- add cronjob guide w/ systemd
- use personal token so that releases are triggered correctly
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).